### PR TITLE
Fix a bug when re-evaluating cf dev bosh env

### DIFF
--- a/src/code.cloudfoundry.org/cfdev/shell/bosh_envs.go
+++ b/src/code.cloudfoundry.org/cfdev/shell/bosh_envs.go
@@ -56,11 +56,11 @@ func (e *Environment) Prepare(config garden.BOSHConfiguration) (string, error) {
 	for _, envvar := range os.Environ() {
 		if strings.HasPrefix(envvar, "BOSH_") {
 			envvar = strings.Split(envvar, "=")[0]
-			fmt.Fprintf(&output, "unset %s\n", envvar)
+			fmt.Fprintf(&output, "unset %s;\n", envvar)
 		}
 	}
 	for _, name := range order {
-		fmt.Fprintf(&output, "export %s=\"%s\"\n", name, values[name])
+		fmt.Fprintf(&output, "export %s=\"%s\";\n", name, values[name])
 	}
 	return output.String(), nil
 }

--- a/src/code.cloudfoundry.org/cfdev/shell/bosh_envs_test.go
+++ b/src/code.cloudfoundry.org/cfdev/shell/bosh_envs_test.go
@@ -41,11 +41,11 @@ var _ = Describe("Formatting BOSH Configuration", func() {
 
 	It("formats BOSH configuration for eval'ing", func() {
 		expectedExports := []string{
-			`export BOSH_ENVIRONMENT="10.245.0.2"`,
-			`export BOSH_CLIENT="admin"`,
-			`export BOSH_CLIENT_SECRET="admin-password"`,
-			`export BOSH_GW_HOST="10.245.0.3"`,
-			`export BOSH_GW_USER="jumpbox"`,
+			`export BOSH_ENVIRONMENT="10.245.0.2";`,
+			`export BOSH_CLIENT="admin";`,
+			`export BOSH_CLIENT_SECRET="admin-password";`,
+			`export BOSH_GW_HOST="10.245.0.3";`,
+			`export BOSH_GW_USER="jumpbox";`,
 
 			// The following items will be saved to files so we
 			// ignore the value for now
@@ -76,13 +76,13 @@ var _ = Describe("Formatting BOSH Configuration", func() {
 		It("unsets any other previously set BOSH environment variables", func() {
 			exports, err := env.Prepare(config)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(exports).To(MatchRegexp(`(?m)^unset BOSH_ALL_PROXY$`))
+			Expect(exports).To(MatchRegexp(`(?m)^unset BOSH_ALL_PROXY;$`))
 		})
 		It("only unsets BOSH_ALL_PROXY if it is currently set", func() {
 			os.Unsetenv("BOSH_ALL_PROXY")
 			exports, err := env.Prepare(config)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(exports).ToNot(ContainSubstring("BOSH_ALL_PROXY"))
+			Expect(exports).ToNot(ContainSubstring("BOSH_ALL_PROXY;"))
 		})
 		It("does not unset  other environment variables", func() {
 			exports, err := env.Prepare(config)


### PR DESCRIPTION
Resolves an issue with `cf dev bosh env` running multiple times.
Upon the second invocation, it will try to unset variables, but when
run in a subshell, the newlines are translated to spaces, and it is executed
in one command, rather than as one command per line.

Fixes errors like:
```
○ → eval $(cf dev bosh env)
○ → eval $(cf dev bosh env)
-bash: unset: `BOSH_ENVIRONMENT=10.245.0.2': not a valid identifier
-bash: unset: `BOSH_CLIENT=admin': not a valid identifier
-bash: unset: `BOSH_CLIENT_SECRET=REDACTED': not a valid identifier
-bash: unset: `BOSH_CA_CERT=/Users/geoff/.cfdev/state/bosh-ca-cert': not a valid identifier
-bash: unset: `BOSH_GW_HOST=10.245.0.2': not a valid identifier
-bash: unset: `BOSH_GW_PRIVATE_KEY=/Users/geoff/.cfdev/state/bosh-gw-key': not a valid identifier
-bash: unset: `BOSH_GW_USER=jumpbox': not a valid identifier
```