### PR TITLE
add hyper-v detect logic for the windows server 2016.

### DIFF
--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -1,11 +1,12 @@
 package host
 
 import (
-	"os/exec"
-	"fmt"
-	"strings"
-	safeerr "code.cloudfoundry.org/cfdev/errors"
 	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	safeerr "code.cloudfoundry.org/cfdev/errors"
 )
 
 const admin_role = "[Security.Principal.WindowsBuiltInRole]::Administrator"
@@ -18,7 +19,6 @@ func (*Host) CheckRequirements() error {
 	return hypervEnabled()
 }
 
-
 func hasAdminPrivileged() error {
 	cmd := exec.Command("powershell.exe", "-Command",
 		fmt.Sprintf("(%s).IsInRole(%s)", current_user, admin_role))
@@ -29,22 +29,31 @@ func hasAdminPrivileged() error {
 	if strings.TrimSpace(string(output)) == "True" {
 		return nil
 	}
-	return safeerr.SafeWrap(errors.New("You must run cf dev with an admin privileged powershell"),"Running without admin privileges")
+	return safeerr.SafeWrap(errors.New("You must run cf dev with an admin privileged powershell"), "Running without admin privileges")
 }
 
-const hyperv_feature="Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online"
-const hyperv_disabled_error=`You must first enable Hyper-V on your machine before you run CF Dev. Please use the following tutorial to enable this functionality on your machine
+const get_feature_cmd_template = "Get-WindowsOptionalFeature -FeatureName %s -Online"
+const hyperv_disabled_error = `You must first enable Hyper-V on your machine before you run CF Dev. Please use the following tutorial to enable this functionality on your machine
 
 https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v`
+
 func hypervEnabled() error {
-	cmd := exec.Command("powershell.exe", "-Command",
-		fmt.Sprintf("(%s).State", hyperv_feature))
-	output, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("checking whether hyperv is enabled: %s", err)
+	hyperv_enabled := true
+	feature_dependency := []string{"Microsoft-Hyper-V", "Microsoft-Hyper-V-Management-PowerShell"}
+	for _, feature := range feature_dependency {
+		feature_check_cmd := fmt.Sprintf(get_feature_cmd_template, feature)
+		cmd := exec.Command("powershell.exe", "-Command",
+			fmt.Sprintf("(%s).State", feature_check_cmd))
+		output, err := cmd.Output()
+		if err != nil {
+			return fmt.Errorf("checking whether hyperv is enabled: %s", err)
+		}
+		if !strings.EqualFold(strings.TrimSpace(string(output)), "Enabled") {
+			hyperv_enabled = false
+		}
 	}
-	if strings.TrimSpace(string(output)) == "Enabled" {
+	if hyperv_enabled {
 		return nil
 	}
-	return safeerr.SafeWrap(errors.New(hyperv_disabled_error),"Hyper-V disabled")
+	return safeerr.SafeWrap(errors.New(hyperv_disabled_error), "Hyper-V disabled")
 }


### PR DESCRIPTION
there's no "Microsoft-Hyper-V-All" in windows server 2016. 
and I think we only need the  "Microsoft-Hyper-V" and "Microsoft-Hyper-V-Management-PowerShell" feature. so check those two instead of "Microsoft-Hyper-V-All"